### PR TITLE
Fix mobile bottom navigation layout

### DIFF
--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { X, Download, Upload, Database } from 'lucide-react';
+import { X, Database } from 'lucide-react';
 import { DataManager } from './DataManager';
 
 interface SettingsModalProps {

--- a/client/src/components/TabNavigation.tsx
+++ b/client/src/components/TabNavigation.tsx
@@ -62,47 +62,49 @@ export const TabNavigation: React.FC<TabNavigationProps> = ({ activeTab, onTabCh
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-black/95 backdrop-blur-lg border-t border-gray-800/50 z-50">
-      <div className="flex justify-around items-center py-2 px-4">
-        {tabs.map((tab) => {
-          const Icon = tab.icon;
-          const isActive = activeTab === tab.id;
-          
-          return (
-            <button
-              key={tab.id}
-              onClick={() => onTabChange(tab.id)}
-              className={`flex items-center justify-center w-12 h-12 rounded-2xl transition-all duration-200 ${
-                isActive 
-                  ? `${tab.bgColor} ${tab.activeColor} scale-105` 
-                  : `${tab.color} hover:bg-gray-800`
-              }`}
-            >
-              <Icon size={24} />
-            </button>
-          );
-        })}
-        
+      <div className="px-4 py-3 space-y-3 max-w-3xl mx-auto">
+        <div className="grid grid-cols-5 gap-2">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeTab === tab.id;
+
+            return (
+              <button
+                key={tab.id}
+                onClick={() => onTabChange(tab.id)}
+                className={`flex items-center justify-center aspect-square rounded-2xl transition-all duration-200 ${
+                  isActive
+                    ? `${tab.bgColor} ${tab.activeColor} scale-[1.02]`
+                    : `${tab.color} hover:bg-gray-800`
+                }`}
+              >
+                <Icon size={22} />
+              </button>
+            );
+          })}
+        </div>
+
         {/* 追加ボタン */}
-        <div className="flex gap-2">
+        <div className="flex justify-center gap-3">
           <button
             onClick={() => onTabChange('add')}
-            className={`flex items-center justify-center w-12 h-12 rounded-full transition-all duration-200 ${
+            className={`flex items-center justify-center w-14 h-14 rounded-full transition-all duration-200 ${
               activeTab === 'add'
-                ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white scale-110 shadow-lg'
+                ? 'bg-gradient-to-r from-blue-500 to-purple-500 text-white scale-105 shadow-lg'
                 : 'bg-gradient-to-r from-blue-500 to-purple-500 text-white hover:scale-105 shadow-md'
             }`}
           >
-            <Plus size={20} />
+            <Plus size={22} />
           </button>
           <button
             onClick={() => onTabChange('voice')}
-            className={`flex items-center justify-center w-12 h-12 rounded-full transition-all duration-200 ${
+            className={`flex items-center justify-center w-14 h-14 rounded-full transition-all duration-200 ${
               activeTab === 'voice'
-                ? 'bg-gradient-to-r from-pink-500 to-rose-500 text-white scale-110 shadow-lg'
+                ? 'bg-gradient-to-r from-pink-500 to-rose-500 text-white scale-105 shadow-lg'
                 : 'bg-gradient-to-r from-pink-500 to-rose-500 text-white hover:scale-105 shadow-md'
             }`}
           >
-            <Mic size={20} />
+            <Mic size={22} />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rework the bottom navigation into a responsive grid with centered quick actions to prevent horizontal overflow on mobile
- adjust floating action button sizing for consistent touch targets
- clean up unused icons in the settings modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d959c1a6d483229c3eedcc6f6a2e90