### PR TITLE
Fix memo card content wrapping

### DIFF
--- a/client/src/components/MemoCard.tsx
+++ b/client/src/components/MemoCard.tsx
@@ -106,7 +106,7 @@ export const MemoCard: React.FC<MemoCardProps> = ({
           
           <div className="flex-1 min-w-0">
             <div className={clsx(
-              'font-semibold text-base truncate text-white',
+              'font-semibold text-base text-white whitespace-pre-wrap break-words',
               memo.is_completed && 'line-through text-gray-400'
             )}>
               {memo.content || 'メモ内容がありません'}


### PR DESCRIPTION
## Summary
- ensure memo card content wraps within the card by replacing the truncation style with wrapping utilities

## Testing
- npm run lint *(fails: ESLint configuration is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9aed6acb88322b9597c501690958d