### PR TITLE
Add memo-style favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ jspm_packages/
 # Gatsby files
 .cache/
 public
+!client/public/
+!client/public/memo-icon.svg
 
 # Storybook build outputs
 .out

--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/memo-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="日々の考え、メモ、タスク、思いつきを管理できるメモアプリ" />
     <title>Memo App - メモとタスク管理</title>

--- a/client/public/memo-icon.svg
+++ b/client/public/memo-icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="memo-gradient" x1="12" y1="10" x2="52" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4f46e5" />
+      <stop offset="1" stop-color="#7c3aed" />
+    </linearGradient>
+    <linearGradient id="memo-top" x1="12" y1="8" x2="52" y2="20" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f9fafb" />
+      <stop offset="1" stop-color="#e5e7eb" />
+    </linearGradient>
+  </defs>
+  <rect x="12" y="8" width="40" height="48" rx="6" fill="url(#memo-gradient)" />
+  <rect x="16" y="12" width="32" height="12" rx="4" fill="url(#memo-top)" />
+  <rect x="18" y="28" width="28" height="4" rx="2" fill="#f9fafb" opacity="0.9" />
+  <rect x="18" y="36" width="24" height="4" rx="2" fill="#f9fafb" opacity="0.8" />
+  <rect x="18" y="44" width="20" height="4" rx="2" fill="#f9fafb" opacity="0.7" />
+  <circle cx="22" cy="18" r="2" fill="#6366f1" />
+  <circle cx="32" cy="18" r="2" fill="#6366f1" />
+  <circle cx="42" cy="18" r="2" fill="#6366f1" />
+</svg>


### PR DESCRIPTION
## Summary
- replace the default Vite favicon reference with a memo-themed icon
- add the memo icon SVG asset and ensure the public folder is tracked in git

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1eae4c44483228b172be27f373877